### PR TITLE
Adding support for multiple formsets with prefixes

### DIFF
--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
@@ -6,19 +6,19 @@
 
 <link href="{% static 'django_bootstrap_dynamic_formsets/extra.css' %}" rel="stylesheet">
 
-<div class="display:none" id="empty-form">
-    <div class="{{ form_wrapper }} sort-item">
+<div class="display:none" id="{{formset.prefix}}-empty-form">
+    <div class="{{ form_wrapper }} sort-item {{formset.prefix}}">
         {% bootstrap_form formset.empty_form layout=layout%}
         <div>
             {% if can_order %}
-                <button type="button" class="btn btn-default btn-sm sort-handle glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
-                <button type="button" class="btn btn-default btn-sm up-form glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
-                <button type="button" class="btn btn-default btn-sm down-form glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm sort-handle-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm up-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm down-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
             {% endif %}
             {% if can_delete %}
-                <button type="button" class="btn btn-default btn-sm delete-form glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm delete-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
             {% endif %}
-            <button type="button" class="btn btn-default btn-sm add-form glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
+            <button type="button" class="btn btn-default btn-sm add-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
         </div>
     </div>
 </div>
@@ -26,18 +26,18 @@
 <div id="sortable">
     {{ formset.management_form }}
     {% for form in formset %}
-        <div class="{{ form_wrapper }} sort-item">
+        <div class="{{ form_wrapper }} sort-item {{formset.prefix}}">
             {% bootstrap_form form layout=layout%}
             <div>
                 {% if can_order %}
-                    <button type="button" class="btn btn-default btn-sm sort-handle glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
-                    <button type="button" class="btn btn-default btn-sm up-form glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
-                    <button type="button" class="btn btn-default btn-sm down-form glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm sort-handle-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm up-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm down-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
                 {% endif %}
                 {% if can_delete %}
-                    <button type="button" class="btn btn-default btn-sm delete-form glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm delete-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
                 {% endif %}
-                <button type="button" class="btn btn-default btn-sm add-form glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm add-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
             </div>
         </div>
     {% endfor %}

--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
@@ -6,19 +6,19 @@
 
 <link href="{% static 'django_bootstrap_dynamic_formsets/extra.css' %}" rel="stylesheet">
 
-<div class="display:none" id="{{formset.prefix}}-empty-form">
+<div class="display:none" id="{% if formset.prefix %}{{formset.prefix}}-{% endif %}empty-form">
     <div class="{{ form_wrapper }} sort-item {{formset.prefix}}">
         {% bootstrap_form formset.empty_form layout=layout%}
         <div>
             {% if can_order %}
-                <button type="button" class="btn btn-default btn-sm sort-handle-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
-                <button type="button" class="btn btn-default btn-sm up-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
-                <button type="button" class="btn btn-default btn-sm down-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm sort-handle{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm up-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm down-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
             {% endif %}
             {% if can_delete %}
-                <button type="button" class="btn btn-default btn-sm delete-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm delete-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
             {% endif %}
-            <button type="button" class="btn btn-default btn-sm add-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
+            <button type="button" class="btn btn-default btn-sm add-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
         </div>
     </div>
 </div>
@@ -30,14 +30,14 @@
             {% bootstrap_form form layout=layout%}
             <div>
                 {% if can_order %}
-                    <button type="button" class="btn btn-default btn-sm sort-handle-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
-                    <button type="button" class="btn btn-default btn-sm up-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
-                    <button type="button" class="btn btn-default btn-sm down-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm sort-handle{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-move" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm up-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-arrow-up" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm down-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-arrow-down" style="vertical-align:middle"></span></button>
                 {% endif %}
                 {% if can_delete %}
-                    <button type="button" class="btn btn-default btn-sm delete-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
+                    <button type="button" class="btn btn-default btn-sm delete-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-trash" style="vertical-align:middle"></span></button>
                 {% endif %}
-                <button type="button" class="btn btn-default btn-sm add-form-{{formset.prefix}} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
+                <button type="button" class="btn btn-default btn-sm add-form{% if formset.prefix %}-{{formset.prefix}}{% endif %} glyph-button"><span class="glyphicon glyphicon-plus" style="vertical-align:middle"></span></button>
             </div>
         </div>
     {% endfor %}

--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
@@ -23,7 +23,7 @@
     </div>
 </div>
 
-<div id="sortable">
+<div id="sortable{% if formset.prefix %}-{{formset.prefix}}{% endif %}">
     {{ formset.management_form }}
     {% for form in formset %}
         <div class="{{ form_wrapper }} sort-item {{formset.prefix}}">

--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
@@ -42,18 +42,18 @@
         $("[id$=DELETE]").parents(".form-group").hide();
 
         //Holds an empty form
-        var $emptyForm = $('#{{formset.prefix}}-empty-form').remove().children().unwrap();
+        var $emptyForm = $('#{% if formset.prefix %}{{formset.prefix}}-{% endif %}empty-form').remove().children().unwrap();
 
         var $sortItem = $('.sort-item.{{formset.prefix}}');
 
         //Disable Up button on first and Down button on last form
         var setUpDownButtons = function () {
             $sortItem = $('.sort-item.{{formset.prefix}}');
-            $sortItem.find(".up-form-{{formset.prefix}}, .down-form-{{formset.prefix}}").each(function () {
+            $sortItem.find(".up-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}, .down-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}").each(function () {
                 $(this).prop("disabled", false);
             });
-            $sortItem.first().find(".up-form-{{formset.prefix}}").prop("disabled", true);
-            $sortItem.last().find(".down-form-{{formset.prefix}}").prop("disabled", true);
+            $sortItem.first().find(".up-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}").prop("disabled", true);
+            $sortItem.last().find(".down-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}").prop("disabled", true);
         };
 
 
@@ -73,7 +73,7 @@
         //$('body').prepend('<p>Count ({{formset.prefix}}): ' + sortItemCounter + '</p>');
 
         //Mark initial forms as such
-        var numInitialForms = $('#id_{{formset.prefix}}-INITIAL_FORMS').val();
+        var numInitialForms = $('#id_{% if formset.prefix %}{{formset.prefix}}-{% endif %}INITIAL_FORMS').val();
         var i = 0;
         $sortItem.each(function () {
             if (i < numInitialForms) {
@@ -84,7 +84,7 @@
             }
         });
 
-        var numTotalForms = $('#id_{{formset.prefix}}-TOTAL_FORMS').val();
+        var numTotalForms = $('#id_{% if formset.prefix %}{{formset.prefix}}-{% endif %}TOTAL_FORMS').val();
         //Fix order (important if page reloads after validation failed)
         for (i = 1; i < numTotalForms; i++) {
             $sortItem.find('[id$=ORDER][value=' + (i + 1) + ']').parents(".sort-item").insertAfter($sortItem.find('[id$=ORDER][value=' + i + ']').parents(".sort-item"));
@@ -110,13 +110,13 @@
             });
             setUpDownButtons();
 
-            $(document).on('click', '.up-form-{{formset.prefix}}', function () {
+            $(document).on('click', '.up-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}', function () {
                 var $parentSortItem = $(this).parents(".sort-item");
                 $parentSortItem.insertBefore($parentSortItem.prev());
                 setUpDownButtons();
             });
 
-            $(document).on('click', '.down-form-{{formset.prefix}}', function () {
+            $(document).on('click', '.down-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}', function () {
                 var $parentSortItem = $(this).parents(".sort-item");
                 $parentSortItem.insertAfter($parentSortItem.next());
                 setUpDownButtons();
@@ -128,11 +128,11 @@
 
 
         // Remove form
-        $(document).on('click', '.delete-form-{{formset.prefix}}', function () {
+        $(document).on('click', '.delete-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}', function () {
         	console.log("Attempting to delete form {{formset.prefix}}");
         	console.log($(this));
             var $parentSortItem = $(this).parents(".sort-item");
-            if ($parentSortItem.hasClass('{{formset.prefix}}-initial-form')) {
+            if ($parentSortItem.hasClass('{% if formset.prefix %}{{formset.prefix}}-{% endif %}initial-form')) {
                 $parentSortItem.effect('drop');
                 $parentSortItem.find('[id$=DELETE]').prop('checked', true);
             } else {
@@ -140,23 +140,23 @@
                     $(this).remove();
                     sortItemCounter--;
                     console.log(sortItemCounter);
-                    $('#id_{{formset.prefix}}-TOTAL_FORMS').attr('value', sortItemCounter);
+                    $('#id_{% if formset.prefix %}{{formset.prefix}}-{% endif %}TOTAL_FORMS').attr('value', sortItemCounter);
                 });
             }
         });
 
         // Add form
-        $(document).on('click', '.add-form-{{formset.prefix}}', function () {
+        $(document).on('click', '.add-form{% if formset.prefix %}-{{formset.prefix}}{% endif %}', function () {
             var formCopy = $emptyForm.clone();
             var formCopyString = formCopy.html().replace(/__prefix__/g, "" + sortItemCounter);
             formCopy.html(formCopyString);
             sortItemCounter++;
             $(this).parents(".sort-item").after(formCopy);
-            $('#id_{{formset.prefix}}-TOTAL_FORMS').attr('value', sortItemCounter);
+            $('#id_{% if formset.prefix %}{{formset.prefix}}-{% endif %}TOTAL_FORMS').attr('value', sortItemCounter);
         });
 
         //Submit formset
-        $('#form-submit-{{formset.prefix}}').click(function (e) {
+        $('#form-submit-{% if formset.prefix %}{{formset.prefix}}{% endif %}').click(function (e) {
             e.preventDefault();
             $('.sort-item.{{formset.prefix}}').each(function () {
                 if (allEmpty($(this))) {

--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
@@ -42,18 +42,18 @@
         $("[id$=DELETE]").parents(".form-group").hide();
 
         //Holds an empty form
-        var $emptyForm = $('#empty-form').remove().children().unwrap();
+        var $emptyForm = $('#{{formset.prefix}}-empty-form').remove().children().unwrap();
 
-        var $sortItem = $('.sort-item');
+        var $sortItem = $('.sort-item.{{formset.prefix}}');
 
         //Disable Up button on first and Down button on last form
         var setUpDownButtons = function () {
-            $sortItem = $('.sort-item');
-            $sortItem.find(".up-form, .down-form").each(function () {
+            $sortItem = $('.sort-item.{{formset.prefix}}');
+            $sortItem.find(".up-form-{{formset.prefix}}, .down-form-{{formset.prefix}}").each(function () {
                 $(this).prop("disabled", false);
             });
-            $sortItem.first().find(".up-form").prop("disabled", true);
-            $sortItem.last().find(".down-form").prop("disabled", true);
+            $sortItem.first().find(".up-form-{{formset.prefix}}").prop("disabled", true);
+            $sortItem.last().find(".down-form-{{formset.prefix}}").prop("disabled", true);
         };
 
 
@@ -70,7 +70,7 @@
         $sortItem.each(function () {
             sortItemCounter++;
         });
-        //$('body').prepend('<p>Count: ' + sortItemCounter + '</p>');
+        //$('body').prepend('<p>Count ({{formset.prefix}}): ' + sortItemCounter + '</p>');
 
         //Mark initial forms as such
         var numInitialForms = $('#id_{{formset.prefix}}-INITIAL_FORMS').val();
@@ -97,7 +97,7 @@
             var $sortable = $('#sortable');
 
             $sortable.sortable({
-                items: ".sort-item",
+                items: ".sort-item.{{formset.prefix}}",
                 axis: "y",
                 scrollSensitivity: 100,
                 scrollSpeed: 5,
@@ -110,13 +110,13 @@
             });
             setUpDownButtons();
 
-            $(document).on('click', '.up-form', function () {
+            $(document).on('click', '.up-form-{{formset.prefix}}', function () {
                 var $parentSortItem = $(this).parents(".sort-item");
                 $parentSortItem.insertBefore($parentSortItem.prev());
                 setUpDownButtons();
             });
 
-            $(document).on('click', '.down-form', function () {
+            $(document).on('click', '.down-form-{{formset.prefix}}', function () {
                 var $parentSortItem = $(this).parents(".sort-item");
                 $parentSortItem.insertAfter($parentSortItem.next());
                 setUpDownButtons();
@@ -128,22 +128,25 @@
 
 
         // Remove form
-        $(document).on('click', '.delete-form', function () {
+        $(document).on('click', '.delete-form-{{formset.prefix}}', function () {
+        	console.log("Attempting to delete form {{formset.prefix}}");
+        	console.log($(this));
             var $parentSortItem = $(this).parents(".sort-item");
-            if ($parentSortItem.hasClass('initial-form')) {
+            if ($parentSortItem.hasClass('{{formset.prefix}}-initial-form')) {
                 $parentSortItem.effect('drop');
                 $parentSortItem.find('[id$=DELETE]').prop('checked', true);
             } else {
                 $parentSortItem.effect('drop', function () {
                     $(this).remove();
                     sortItemCounter--;
+                    console.log(sortItemCounter);
                     $('#id_{{formset.prefix}}-TOTAL_FORMS').attr('value', sortItemCounter);
                 });
             }
         });
 
         // Add form
-        $(document).on('click', '.add-form', function () {
+        $(document).on('click', '.add-form-{{formset.prefix}}', function () {
             var formCopy = $emptyForm.clone();
             var formCopyString = formCopy.html().replace(/__prefix__/g, "" + sortItemCounter);
             formCopy.html(formCopyString);
@@ -153,11 +156,16 @@
         });
 
         //Submit formset
-        $('#form-submit').click(function (e) {
+        $('#form-submit-{{formset.prefix}}').click(function (e) {
             e.preventDefault();
-            $('.sort-item').each(function () {
+            $('.sort-item.{{formset.prefix}}').each(function () {
                 if (allEmpty($(this))) {
+                	console.log("I'm all empty, so removing myself!")
                     $(this).remove();
+                }
+                else
+                {
+                	console.log("Not empty, so not removing!")
                 }
             });
             {% if can_order %}

--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets_js.html
@@ -94,7 +94,7 @@
         //Set up sortable jQuery UI interaction
         {% if can_order %}
 
-            var $sortable = $('#sortable');
+            var $sortable = $('#sortable{% if formset.prefix %}-{{formset.prefix}}{% endif %}');
 
             $sortable.sortable({
                 items: ".sort-item.{{formset.prefix}}",
@@ -102,7 +102,7 @@
                 scrollSensitivity: 100,
                 scrollSpeed: 5,
                 tolerance: "intersect",
-                handle: ".sort-handle",
+                handle: ".sort-handle{% if formset.prefix %}-{{formset.prefix}}{% endif %}",
                 cancel: "input,textarea,select,option"
             });
             $sortable.on("sortupdate", function (event, ui) {


### PR DESCRIPTION
I'm looking this over and I just realized that it's a little ugly; it'll add in a bunch of leading or trailing dashes if you make a form without any prefixes.  I don't think that'll break either the CSS or the javascript, but I honestly don't know.  I can definitely clean up the generated markup but it'll make the code uglier with a lot of {% if formset.prefix %}-{{ formset.prefix }}{% endif %} everywhere instead of just -{{ formset.prefix}}.
