### PR TITLE
Replace load staticfiles with load static

### DIFF
--- a/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
+++ b/django_bootstrap_dynamic_formsets/templates/django_bootstrap_dynamic_formsets/dynamic_formsets.html
@@ -1,6 +1,6 @@
 {% load bootstrap3 %}
 {% load bootstrap_dynamic_formsets %}
-{% load staticfiles %}
+{% load static %}
 
 {% bootstrap_dynamic_formset_js %}
 

--- a/testapp/templates/testapp/base.html
+++ b/testapp/templates/testapp/base.html
@@ -2,7 +2,7 @@
 <html>
 <head lang="en">
     {% block head %}{% endblock %}
-    {% load staticfiles %}
+    {% load static %}
     {% load bootstrap3 %}
     <script src="https://code.jquery.com/jquery-1.11.1.min.js"></script>
     <script src="https://code.jquery.com/ui/1.11.1/jquery-ui.min.js"></script>


### PR DESCRIPTION
This was deprecated in django 2.1 and removed in django 3.0 https://docs.djangoproject.com/en/4.2/releases/2.1/#id2 https://docs.djangoproject.com/en/4.2/releases/3.0/#features-removed-in-3-0